### PR TITLE
Enable Gau-PBE and remove failing conversion

### DIFF
--- a/qespresso/converters.py
+++ b/qespresso/converters.py
@@ -358,12 +358,12 @@ class PwInputConverter(RawInputConverter):
                     'nqx2': 'SYSTEM[nqx2]',
                     'nqx3': 'SYSTEM[nqx3]'
                 },
-                'ecutfock': ('SYSTEM[ecutfock]',options.Ha2Ry, None),
+                'ecutfock': 'SYSTEM[ecutfock]',
                 'exx_fraction': 'SYSTEM[exx_fraction]',
                 'screening_parameter': 'SYSTEM[screening_parameter]',
                 'exxdiv_treatment': 'SYSTEM[exxdiv_treatment]',
                 'x_gamma_extrapolation': 'SYSTEM[x_gamma_extrapolation]',
-                'ecutvcut': ('SYSTEM[ecutvcut]', options.Ha2Ry, None)
+                'ecutvcut': 'SYSTEM[ecutvcut]'
             },
             'dftU': {
                 'lda_plus_u_kind': 'SYSTEM[lda_plus_u_kind]',

--- a/qespresso/scheme/qes.xsd
+++ b/qespresso/scheme/qes.xsd
@@ -252,6 +252,7 @@ Authors: Antonio Zambon, Paolo Giannozzi, Pietro Delugas
     <enumeration value="SOGGA"/>
     <enumeration value="EV93"/>
     <enumeration value="B3LYP"/>
+    <enumeration value="Gau-PBE"/>
     <enumeration value="PBE0"/>
     <enumeration value="HSE"/>
     <enumeration value="VDW-DF"/>

--- a/qespresso/scheme/qes_neb_temp.xsd
+++ b/qespresso/scheme/qes_neb_temp.xsd
@@ -391,6 +391,7 @@ Authors: Paolo Giannozzi, Pietro Delugas
     <enumeration value="SOGGA"/>
     <enumeration value="EV93"/>
     <enumeration value="B3LYP"/>
+    <enumeration value="Gau-PBE"/>
     <enumeration value="PBE0"/>
     <enumeration value="HSE"/>
     <enumeration value="VDW-DF"/>

--- a/qespresso/scheme/qes_with_choice_no_nesting.xsd
+++ b/qespresso/scheme/qes_with_choice_no_nesting.xsd
@@ -252,6 +252,7 @@ Authors: Antonio Zambon, Paolo Giannozzi, Pietro Delugas
     <enumeration value="SOGGA"/>
     <enumeration value="EV93"/>
     <enumeration value="B3LYP"/>
+    <enumeration value="Gau-PBE"/>
     <enumeration value="PBE0"/>
     <enumeration value="HSE"/>
     <enumeration value="VDW-DF"/>


### PR DESCRIPTION
Conversion is not used in ecutwfc for example. Tested manually.